### PR TITLE
Fixed memory leak

### DIFF
--- a/core/src/com/dicycat/kroy/entities/FireTruck.java
+++ b/core/src/com/dicycat/kroy/entities/FireTruck.java
@@ -147,11 +147,12 @@ public class FireTruck extends Entity{
 		
 		//Move the hit box to it's new centred position according to the sprite's position.
         hitbox.setCenter(getCentre().x, getCentre().y);
-        
-        //Draw debugs
-    	Kroy.mainGameScreen.DrawRect(new Vector2(hitbox.x, hitbox.y), new Vector2(hitbox.width, hitbox.height), 2, Color.GREEN);
-    	Kroy.mainGameScreen.DrawCircle(getCentre(), range, 1, Color.BLUE);
-		
+
+        // START OF MODIFICATION - NP STUDIOS -----------------------------------------
+
+		// Deleted debug hitbox being drawn to the screen even if drawDebug in GameScreen == false.
+
+		// END OF MODIFICATION  - NP STUDIOS -----------------------------------------
 
 		//water bar update
 		tank.setPosition(getCentre().add(0,20));

--- a/core/src/com/dicycat/kroy/screens/GameScreen.java
+++ b/core/src/com/dicycat/kroy/screens/GameScreen.java
@@ -260,7 +260,13 @@ public class GameScreen implements Screen{
 	 * @param colour Colour of the line
 	 */
 	public void DrawLine(Vector2 start, Vector2 end, int lineWidth, Color colour) {
+		// START OF MODIFICATION - NP STUDIOS -----------------------------------------
+		// Added an if statement to fully ensure debugging view is requested as we noticed the original teams debug
+		// code causes a memory leak and possibly crashes the game overtime.
+		if (showDebug) {
 		debugObjects.add(new DebugLine(start, end, lineWidth, colour));
+		}
+		// END OF MODIFICATION - NP STUDIOS -----------------------------------------
 	}
 
 	/**
@@ -271,7 +277,13 @@ public class GameScreen implements Screen{
 	 * @param colour Colour of the line
 	 */
 	public void DrawCircle(Vector2 position, float radius, int lineWidth, Color colour) {
-		debugObjects.add(new DebugCircle(position, radius, lineWidth, colour));
+		// START OF MODIFICATION - NP STUDIOS -----------------------------------------
+		// Added an if statement to fully ensure debugging view is requested as we noticed the original teams debug
+		// code causes a memory leak and possibly crashes the game overtime.
+		if (showDebug) {
+			debugObjects.add(new DebugCircle(position, radius, lineWidth, colour));
+		}
+		// END OF MODIFICATION - NP STUDIOS -----------------------------------------
 	}
 
 	/**
@@ -282,7 +294,13 @@ public class GameScreen implements Screen{
 	 * @param colour Colour of the line
 	 */
 	public void DrawRect(Vector2 bottomLeft, Vector2 dimensions, int lineWidth, Color colour) {
-		debugObjects.add(new DebugRect(bottomLeft, dimensions, lineWidth, colour));
+		// START OF MODIFICATION - NP STUDIOS -----------------------------------------
+		// Added an if statement to fully ensure debugging view is requested as we noticed the original teams debug
+		// code causes a memory leak and possibly crashes the game overtime.
+		if (showDebug) {
+			debugObjects.add(new DebugRect(bottomLeft, dimensions, lineWidth, colour));
+		}
+		// END OF MODIFICATION - NP STUDIOS -----------------------------------------
 	}
 
 	/**


### PR DESCRIPTION
The debug methods in the GameScreen class were still being drawn behind the game when `showDebug = false`. These debug renders caused a memory leak and over time could cause the game to crash, we have therefore added if statements to check the status of `showDebug` and currently disabled it for now. 